### PR TITLE
Fixed error on servers which were not yet checked

### DIFF
--- a/http.go
+++ b/http.go
@@ -28,6 +28,9 @@ func calculateServerUptime(statusAtTime []*statusAtTime) string {
 }
 
 func lastStatus(statusAtTime []*statusAtTime) string {
+	if len(statusAtTime) == 0 {
+		return "Not yet checked"
+	}
 	lastChecked := statusAtTime[len(statusAtTime)-1]
 	difference := time.Since(lastChecked.Time)
 	status := "OK"


### PR DESCRIPTION
Previously when accessing the webinterface directly after launching gossm, it would result in an internal server error because `lastStatus` is trying to access an empty array. This PR checks the size of the array beforehand.